### PR TITLE
Fix ESLint disable comment syntax in BlogpostLayout.astro

### DIFF
--- a/src/layouts/BlogpostLayout.astro
+++ b/src/layouts/BlogpostLayout.astro
@@ -37,9 +37,7 @@ const currentURL = Astro.request.url;
   <article class="h-entry">
     <!-- h-entry things -->
     <div class="hidden">
-      // eslint-disable-next-line astro/jsx-a11y/anchor-has-content,
-      astro/jsx-a11y/anchor-has-content // eslint-disable-next-line
-      astro/jsx-a11y/anchor-has-content
+      {/* eslint-disable-next-line astro/jsx-a11y/anchor-has-content */}
       <a href={currentURL} u-url></a>
 
       <time class="dt-published">{new Date(pubDate).toUTCString()}</time>

--- a/src/layouts/BlogpostLayout.astro
+++ b/src/layouts/BlogpostLayout.astro
@@ -37,6 +37,7 @@ const currentURL = Astro.request.url;
   <article class="h-entry">
     <!-- h-entry things -->
     <div class="hidden">
+      {/* Intentionally empty anchor for h-entry microformat u-url */}
       {/* eslint-disable-next-line astro/jsx-a11y/anchor-has-content */}
       <a href={currentURL} u-url></a>
 


### PR DESCRIPTION
## Summary
- Corrects the syntax of the ESLint disable comment in `BlogpostLayout.astro` to properly disable the `astro/jsx-a11y/anchor-has-content` rule

## Changes

### Code Quality
- Replaced multiple incorrect ESLint disable comments with a single properly formatted JSX comment
- Ensures the anchor element without content does not trigger accessibility linting errors

## Test plan
- [x] Verify no ESLint warnings or errors related to `anchor-has-content` in `BlogpostLayout.astro`
- [x] Confirm the anchor element remains correctly rendered and accessible
- [x] Run existing tests to ensure no regressions in layout or functionality

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/794dadda-1ff7-450f-9329-7342b2eeaefa