### PR TITLE
Enable CORS on RSS feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ pnpm-debug.log*
 dev.pid
 test-results
 playwright-report
+logs

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -9,7 +9,7 @@ const parser = new MarkdownIt();
 
 export async function GET(context: { site: any }) {
   const blog: CollectionEntry<"blog">[] = await getCollection("blog");
-  return rss({
+  const response = await rss({
     title: siteData.title,
     description: siteData.description,
     site: context.site,
@@ -21,4 +21,11 @@ export async function GET(context: { site: any }) {
       content: sanitizeHtml(parser.render(post.body || "")),
     })),
   });
+
+  // Add CORS headers to allow cross-origin requests
+  response.headers.set("Access-Control-Allow-Origin", "*");
+  response.headers.set("Access-Control-Allow-Methods", "GET");
+  response.headers.set("Access-Control-Allow-Headers", "Content-Type");
+
+  return response;
 }


### PR DESCRIPTION
Added Access-Control-Allow-Origin, Access-Control-Allow-Methods, and
Access-Control-Allow-Headers to allow cross-origin requests to the RSS feed.
This enables external applications and services to fetch the RSS feed from
different domains.