### PR TITLE
Add month headers to shapenote compositions

### DIFF
--- a/src/pages/shapenote-compositions.astro
+++ b/src/pages/shapenote-compositions.astro
@@ -1,5 +1,6 @@
 ---
 import PageLayout from "@/layouts/PageLayout.astro";
+import getMonthYear from "@/utils/getMonthYear";
 import { titleCase } from "title-case";
 
 const title = "Shapenote Compositions";
@@ -61,12 +62,6 @@ const compositions: CompositionPdf[] = Object.entries(pdfFiles)
 
 let currentCompositionMonth = "";
 let compositionMonth = "";
-
-const getMonthYear = (date: Date) =>
-  date.toLocaleDateString("en-GB", {
-    month: "long",
-    year: "numeric",
-  });
 
 const setCurrentCompositionMonth = (date: Date) => {
   currentCompositionMonth = getMonthYear(date);

--- a/src/pages/shapenote-compositions.astro
+++ b/src/pages/shapenote-compositions.astro
@@ -59,13 +59,27 @@ const compositions: CompositionPdf[] = Object.entries(pdfFiles)
       a.name.localeCompare(b.name),
   );
 
+let currentCompositionMonth = "";
+let compositionMonth = "";
+
+const getMonthYear = (date: Date) =>
+  date.toLocaleDateString("en-GB", {
+    month: "long",
+    year: "numeric",
+  });
+
+const setCurrentCompositionMonth = (date: Date) => {
+  currentCompositionMonth = getMonthYear(date);
+};
+
+const setCompositionMonth = (date: Date) => {
+  compositionMonth = getMonthYear(date);
+};
+
 // The workflow stores month-level composition dates as the first day of the month.
 function formatDate(date: Date): string {
   if (date.getDate() === 1) {
-    return date.toLocaleDateString("en-GB", {
-      month: "long",
-      year: "numeric",
-    });
+    return getMonthYear(date);
   }
 
   return date.toLocaleDateString("en-GB", {
@@ -89,18 +103,28 @@ function formatDate(date: Date): string {
   <ul class="mt-6 flex list-none flex-col gap-4">
     {
       compositions.map((composition) => (
-        <li class="flex flex-col gap-0.5">
-          <a
-            href={composition.url}
-            class="font-semibold hover:underline"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {titleCase(composition.name.replace(/-/g, " "))}
-          </a>
-          <span class="text-sm text-gray-600 dark:text-gray-400">
-            {formatDate(composition.lastUpdated)}
-          </span>
+        <li>
+          {setCurrentCompositionMonth(composition.lastUpdated)}
+          {compositionMonth !== currentCompositionMonth && (
+            <p class="mt-16 mb-8 text-3xl font-bold text-[#DA291C] first:mt-0">
+              {currentCompositionMonth}
+            </p>
+          )}
+          {setCompositionMonth(composition.lastUpdated)}
+
+          <div class="flex flex-col gap-0.5 border-l py-2 pl-4">
+            <a
+              href={composition.url}
+              class="font-semibold hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {titleCase(composition.name.replace(/-/g, " "))}
+            </a>
+            <span class="text-sm text-gray-600 dark:text-gray-400">
+              {formatDate(composition.lastUpdated)}
+            </span>
+          </div>
         </li>
       ))
     }

--- a/src/utils/getMonthYear.test.ts
+++ b/src/utils/getMonthYear.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vite-plus/test";
+import getMonthYear from "./getMonthYear";
+
+describe("getMonthYear", () => {
+  it("should format a date as month and year", () => {
+    const input = new Date(2024, 0, 15);
+
+    const result = getMonthYear(input);
+
+    expect(result).toBe("January 2024");
+  });
+
+  it("should handle dates from different months and years", () => {
+    const input = new Date(1999, 11, 31);
+
+    const result = getMonthYear(input);
+
+    expect(result).toBe("December 1999");
+  });
+
+  it("should handle dates created from timestamps", () => {
+    const input = new Date(1704067200000);
+
+    const result = getMonthYear(input);
+
+    expect(result).toBe("January 2024");
+  });
+});

--- a/src/utils/getMonthYear.ts
+++ b/src/utils/getMonthYear.ts
@@ -1,0 +1,6 @@
+export default function getMonthYear(date: Date): string {
+  return new Intl.DateTimeFormat("en-GB", {
+    month: "long",
+    year: "numeric",
+  }).format(new Date(date));
+}


### PR DESCRIPTION
### Motivation
- Make the shapenote compositions list easier to scan by grouping entries by composition month and year and reuse the blog-style section header pattern.

### Description
- Updated `src/pages/shapenote-compositions.astro` to add grouping state (`currentCompositionMonth`, `compositionMonth`) and helper `getMonthYear` to format month/year strings.
- Reworked `formatDate` to delegate month-year formatting to `getMonthYear` for entries stored as the first day of the month.
- Inserted month/year section headers into the compositions list whenever the composition month changes and wrapped items in a bordered container to match the blog list styling.
- Kept the existing sorting and filename-parsing logic while updating the rendered markup to include the new headers and layout.

### Testing
- Ran `vp check` which completed successfully and fixed formatting where needed.
- Ran `vp test` and all tests passed (`36` tests passed in this environment).
- Ran `vp run build` which completed successfully despite a font-provider warning about fetching Google Fonts.
- `vp install` could not complete due to a network error fetching the `pnpm` package and Playwright screenshot capture failed because browser binaries are not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b149ccfc4832baf56deb84937543d)